### PR TITLE
bugfix/promt-issue-#29

### DIFF
--- a/release/src/preparer/Translate.py
+++ b/release/src/preparer/Translate.py
@@ -1,6 +1,6 @@
 import hashlib, json, functools
 from pathlib import Path
-from release.src.utils.ConsoleIO import print_status, promt
+from release.src.utils.ConsoleIO import print_status, prompt
 
 def update_registry_on_success(func):
     @functools.wraps(func)


### PR DESCRIPTION
Closes #29 

## Description
fix typo (promt instead prompt) which failed build release bundle

## What Was Done
```python
# prev
from release.src.utils.ConsoleIO import print_status, promt
# now
from release.src.utils.ConsoleIO import print_status, prompt
```

## How to Test
Try to build

## Checklist
- [x] Code builds and runs correctly
- [x] PR has appropriate reviewers and labels
- [x] Requires at least **2** approvals